### PR TITLE
Meson and some README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ archives:
 # tiu create --tar system-update.tar.xz
 ```
 
+This will try to create a `btrfs` subvolume in _$TMPDIR_.  If this
+directory is not under a `btrfs` filesystem `tiu` will complain with
+"ERROR: not a btrfs filesystem: /tmp/tiu-workdir-XXXXXXXXXX" message.
+The solution is execute it with a different default directory.
+
+```
+# TMPDIR=/var/cache/tiu tiu create --tar system-update.tar.xz
+```
+
 ### Extracting tiu archive
 
 ```

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,7 @@ project('tiu', 'c',
 		'prefix=/usr',
 		'sysconfdir=/etc',
 		'localstatedir=/var',
+		'werror=true',
 	],
 	meson_version : '>= 0.49.0',
 )
@@ -23,7 +24,6 @@ add_project_arguments(['-D_GNU_SOURCE=1',
 		       '-D_FORTIFY_SOURCE=2'], language : 'c')
 
 possible_cc_flags = [
-		  '-Werror',
 		  '-fstack-protector-strong',
 		  '-funwind-tables',
 		  '-fasynchronous-unwind-tables',


### PR DESCRIPTION
In Tumbleweed `/tmp` is a `tmpfs` and not a `btrfs` filesystem, this makes `tiu` fails by default. This document a workaround but maybe a proper fix is required, like defaulting to `/var/cache/tiu`